### PR TITLE
remove fixed-width (causes horizontal overflow on small screens)

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 	    </div>
 
 	    <section id="hero-area">
-	        <div class="container" style="width:1600px">
+	        <div class="container" style="width:100%">
 	            <div class="row">
 	                <div class="col-md-12">
 	                    <div class="block">


### PR DESCRIPTION
With the page width fixed at `1600px`, there is some horizontal overflow on small screens:

![deepinscreenshot_select-area_20181229012918](https://user-images.githubusercontent.com/32495955/50534349-54fd2c00-0b09-11e9-9425-f73070249837.png)
